### PR TITLE
Fix NaN in sqrt formula

### DIFF
--- a/Src/mpu6050.c
+++ b/Src/mpu6050.c
@@ -182,8 +182,7 @@ void MPU6050_Read_All(I2C_HandleTypeDef *I2Cx, MPU6050_t *DataStruct)
     double dt = (double)(HAL_GetTick() - timer) / 1000;
     timer = HAL_GetTick();
     double roll;
-    double roll_sqrt = sqrt(
-        DataStruct->Accel_X_RAW * DataStruct->Accel_X_RAW + DataStruct->Accel_Z_RAW * DataStruct->Accel_Z_RAW);
+    double roll_sqrt = sqrt(pow(DataStruct->Accel_X_RAW, 2) + pow(DataStruct->Accel_Z_RAW, 2));
     if (roll_sqrt != 0.0)
     {
         roll = atan(DataStruct->Accel_Y_RAW / roll_sqrt) * RAD_TO_DEG;


### PR DESCRIPTION
When Gyro_X_Raw and Gyro_Z_Raw are both -32768, this results in NaN in the square root calculation when the calculation to the power of two is done with var x var. Using the math method pow() solves the problem.

![image](https://github.com/leech001/MPU6050/assets/1044439/fb446cdc-e3c5-4a4b-9677-8401cecd631e)
